### PR TITLE
Remove site pictures

### DIFF
--- a/style.css
+++ b/style.css
@@ -473,3 +473,8 @@ footer {
 }
 .hint-box.purple { background: #f4f2ff; border-color: #d5cff8; }
 .hint-box ul { margin: 0.25rem 0 0 1rem; }
+
+/* Hide all images site-wide */
+img {
+  display: none !important;
+}


### PR DESCRIPTION
Add CSS rule to `style.css` to hide all `<img>` elements site-wide, fulfilling the request to remove pictures.

---
<a href="https://cursor.com/background-agent?bcId=bc-8635a478-7d05-4847-838e-5ad23fe74bc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8635a478-7d05-4847-838e-5ad23fe74bc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

