### PR TITLE
Remove pictures

### DIFF
--- a/style.css
+++ b/style.css
@@ -499,3 +499,11 @@ footer {
   opacity: 0.5;
   pointer-events: none;
 }
+
+/*
+ * Hide all decorative images across the site. All inline images use the
+ * `responsive` class, so disable their display globally.
+ */
+img.responsive {
+  display: none !important;
+}


### PR DESCRIPTION
Add CSS rule to `style.css` to hide all images with the `responsive` class, effectively removing all pictures from the site.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e781cc3-dde6-4c8c-b31c-23665967a70d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e781cc3-dde6-4c8c-b31c-23665967a70d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

