### PR TITLE
Add white text to blue button

### DIFF
--- a/style.css
+++ b/style.css
@@ -452,6 +452,11 @@ footer {
   text-decoration: none;
   font-weight: 700;
 }
+/* Ensure white text for buttons within category cards, overriding generic link styles */
+.category-card .btn-link,
+.category-card .btn-link:hover {
+  color: #ffffff;
+}
 
 /* Hint boxes */
 .hint-container { margin: 0.75rem 0 1rem 0; }


### PR DESCRIPTION
Add white text to the blue 'Explore' button within category cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-06462d87-1bb6-4fcd-b79d-5be2ea2a7cf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06462d87-1bb6-4fcd-b79d-5be2ea2a7cf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

