### PR TITLE
Remove hose holder references from website

### DIFF
--- a/assessments.html
+++ b/assessments.html
@@ -17,10 +17,10 @@
 <main>
 <div class="card">
 <h2>Assessment Overview</h2>
-<p>Students will be assessed on their ability to design, plan, produce, evaluate and reflect on a functioning hose reel holder. Assessment components include:</p>
+<p>Students will be assessed on their ability to design, plan, produce, evaluate and reflect on a functioning metalwork project. Assessment components include:</p>
 <ul>
 <li><strong>Quizzes:</strong> Each unit page contains a short multiple‑choice quiz. Completion and performance contribute to formative assessment.</li>
-<li><strong>Practical Project:</strong> The finished hose holder is assessed on how well it meets the brief (function, strength, safety and finish) and demonstrates safe and skilful use of tools.</li>
+<li><strong>Practical Project:</strong> The finished project is assessed on how well it meets the brief (function, strength, safety and finish) and demonstrates safe and skilful use of tools.</li>
 <li><strong>Portfolio:</strong> The design portfolio documents research, ideas, planning, making, testing and reflection. It should show evidence for all outcomes.</li>
 <li><strong>Reflection:</strong> Students present their projects and reflect on their learning. A short written quiz may also cover key knowledge from the unit.</li>
 </ul>
@@ -28,6 +28,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/external_resources.html
+++ b/external_resources.html
@@ -93,6 +93,6 @@
   <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hose Reel Holder Unit</title>
+  <title>Metalwork Project Unit</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <header>
-  <h1>Hose Reel Holder Project</h1>
+  <h1>Metalwork Project</h1>
   <p>Year 8 Technology Mandatory – Metalwork</p>
 </header>
 <nav>
@@ -104,6 +104,6 @@
   <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/interactive_scenarios.html
+++ b/interactive_scenarios.html
@@ -9,7 +9,7 @@
 <body>
 <header>
   <h1>Interactive Scenario Questions</h1>
-  <p>Engage with real‑world situations related to each week of the hose reel holder project.</p>
+  <p>Engage with real‑world situations related to each week of the metalwork project unit.</p>
 </header>
 <nav>
   <a href="index.html">Home</a>
@@ -36,6 +36,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/program.html
+++ b/program.html
@@ -17,7 +17,7 @@
 <main>
 <div class="card">
 <h2>Weekly Schedule</h2>
-<p>This program outlines the focus, activities and outcomes for each week of the Hose Reel Holder project. Teachers may adapt dates and registration details to suit their class timetable.</p>
+<p>This program outlines the focus, activities and outcomes for each week of the metalwork project unit. Teachers may adapt dates and registration details to suit their class timetable.</p>
 <table style="width:100%; border-collapse: collapse;">
 <thead><tr><th style="border:1px solid #ccc; padding:8px;">Week</th><th style="border:1px solid #ccc; padding:8px;">Focus</th><th style="border:1px solid #ccc; padding:8px;">Activities</th><th style="border:1px solid #ccc; padding:8px;">Outcomes</th></tr></thead><tbody>
 <tr>
@@ -29,7 +29,7 @@
 <tr>
 <td style="border:1px solid #ccc; padding:8px; vertical-align: top;">2</td>
 <td style="border:1px solid #ccc; padding:8px; vertical-align: top;">Design & Planning</td>
-<td style="border:1px solid #ccc; padding:8px; vertical-align: top;">Research existing holders, brainstorm ideas, plan design and production steps.</td>
+<td style="border:1px solid #ccc; padding:8px; vertical-align: top;">Research existing products, brainstorm ideas, plan design and production steps.</td>
 <td style="border:1px solid #ccc; padding:8px; vertical-align: top;">TE4-1DP, TE4-2DP</td>
 </tr>
 <tr>
@@ -65,7 +65,7 @@
 <tr>
 <td style="border:1px solid #ccc; padding:8px; vertical-align: top;">8</td>
 <td style="border:1px solid #ccc; padding:8px; vertical-align: top;">Testing & Evaluation</td>
-<td style="border:1px solid #ccc; padding:8px; vertical-align: top;">Mount and test the holder; gather feedback; evaluate against criteria; reflect on improvements.</td>
+<td style="border:1px solid #ccc; padding:8px; vertical-align: top;">Mount and test the project; gather feedback; evaluate against criteria; reflect on improvements.</td>
 <td style="border:1px solid #ccc; padding:8px; vertical-align: top;">TE4-1DP, TE4-10TS</td>
 </tr>
 <tr>
@@ -85,6 +85,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario1.html
+++ b/scenario1.html
@@ -110,6 +110,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario10.html
+++ b/scenario10.html
@@ -89,6 +89,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario2.html
+++ b/scenario2.html
@@ -18,7 +18,7 @@
 <main>
   <div class="card">
     <h2>Scenario</h2>
-    <p>A student rushes through the planning stage of their hose reel holder. They sketch a rough idea without measurements, forget to prepare a materials list and jump straight into cutting materials. Halfway through, they realise the parts don’t fit together and they are running out of steel. The student becomes frustrated because they have to start over.</p>
+    <p>A student rushes through the planning stage of their project. They sketch a rough idea without measurements, forget to prepare a materials list and jump straight into cutting materials. Halfway through, they realise the parts don’t fit together and they are running out of steel. The student becomes frustrated because they have to start over.</p>
   </div>
   <form class="scenario-form" data-unit="2">
     <!-- Q1: Multiple‑choice -->
@@ -92,6 +92,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario3.html
+++ b/scenario3.html
@@ -116,6 +116,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario4.html
+++ b/scenario4.html
@@ -107,6 +107,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario5.html
+++ b/scenario5.html
@@ -93,6 +93,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario6.html
+++ b/scenario6.html
@@ -18,7 +18,7 @@
 <main>
   <div class="card">
     <h2>Scenario</h2>
-    <p>A student is eager to assemble the hose reel holder. They start attaching parts without checking that holes align or that the frame is square. They do not dry‑fit components first. Later, they discover the holder is crooked and parts don’t fit; they must dismantle and re‑drill holes.</p>
+    <p>A student is eager to assemble their project. They start attaching parts without checking that holes align or that the frame is square. They do not dry‑fit components first. Later, they discover the assembly is crooked and parts don’t fit; they must dismantle and re‑drill holes.</p>
   </div>
   <form class="scenario-form" data-unit="6">
     <!-- Q1: Multiple‑choice -->
@@ -107,6 +107,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario7.html
+++ b/scenario7.html
@@ -18,7 +18,7 @@
 <main>
   <div class="card">
     <h2>Scenario</h2>
-    <p>After completing assembly, a student decides to paint the hose reel holder. They skip sanding and cleaning because the metal looks smooth. They apply a thick coat of paint straight from the can without primer. The next day the paint peels and the finish is uneven.</p>
+    <p>After completing assembly, a student decides to paint their project. They skip sanding and cleaning because the metal looks smooth. They apply a thick coat of paint straight from the can without primer. The next day the paint peels and the finish is uneven.</p>
   </div>
   <form class="scenario-form" data-unit="7">
     <!-- Q1: Multiple‑choice -->
@@ -107,6 +107,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario8.html
+++ b/scenario8.html
@@ -18,7 +18,7 @@
 <main>
   <div class="card">
     <h2>Scenario</h2>
-    <p>After finishing their hose reel holder, a student decides it’s done and puts it aside without testing it. During grading, the hose reel won’t fit properly and the holder flexes under load. The student is disappointed by the low mark.</p>
+    <p>After finishing their project, a student decides it’s done and puts it aside without testing it. During grading, parts don’t fit properly and the assembly flexes under load. The student is disappointed by the low mark.</p>
   </div>
   <form class="scenario-form" data-unit="8">
     <!-- Q1: Multiple‑choice -->
@@ -47,7 +47,7 @@
       <p>Rate your finished project:</p>
       <table>
         <tr><th>Aspect</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th></tr>
-        <tr><td>Fit of the hose reel</td>
+        <tr><td>Fit of mating parts</td>
           <td><input type="radio" name="q3a" value="1"></td>
           <td><input type="radio" name="q3a" value="2"></td>
           <td><input type="radio" name="q3a" value="3"></td>
@@ -97,6 +97,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/scenario9.html
+++ b/scenario9.html
@@ -107,6 +107,6 @@
   </form>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -721,7 +721,7 @@ function applySupportPageChrome() {
   // Standard footer if missing
   if (!document.querySelector('footer')) {
     const footer = document.createElement('footer');
-    footer.innerHTML = '&copy; 2025 Hose\u00A0Reel Holder Project';
+    footer.innerHTML = '&copy; 2025 Metalwork Project Unit';
     document.body.appendChild(footer);
   }
 }

--- a/syllabus.html
+++ b/syllabus.html
@@ -17,7 +17,7 @@
 <main>
 <div class="card">
 <h2>Stage 4 Technology Mandatory Outcomes</h2>
-<p>The hose reel holder unit aligns with the NSW Stage 4 Technology Mandatory syllabus. Key outcomes addressed include:</p>
+<p>This metalwork project unit aligns with the NSW Stage 4 Technology Mandatory syllabus. Key outcomes addressed include:</p>
 <ul>
 <li><strong>TE4‑1DP:</strong> Students design, communicate and evaluate products and processes that solve real and relevant problems.</li>
 <li><strong>TE4‑2DP:</strong> Students plan and manage the production of designed solutions, including safe use of tools and resources.</li>
@@ -30,6 +30,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit1.html
+++ b/unit1.html
@@ -22,7 +22,7 @@
 <div class="card">
 <img src="img/header_abstract.png" alt="Illustration" class="responsive">
 <h2>Week 1 – Introduction & Safety</h2>
-<p>This week introduces the hose reel holder project and the foundations of metalwork. Students learn that hoses left lying around can become messy and hazardous, so their task is to design and make a wall‑mounted metal holder that keeps the hose coiled neatly. We discuss why mild steel is chosen – it’s strong, weather resistant and easy to work with compared to wood or plastic. Safety is paramount: we cover workshop rules such as always wearing safety glasses, tying back long hair, using ear and hand protection, and never operating machines without teacher permission. A safety contract is signed and a safety quiz must be passed before anyone may use the tools. Students sketch their first ideas for the holder at the end of the week.</p>
+<p>This week introduces the term project and the foundations of metalwork. Students learn how designed solutions solve everyday problems, such as tidy storage and safer spaces. The class will design and make a small metal product using mild steel because it’s strong, weather resistant and workable compared to wood or plastic. Safety is paramount: we cover workshop rules such as always wearing safety glasses, tying back long hair, using ear and hand protection, and never operating machines without teacher permission. A safety contract is signed and a safety quiz must be passed before anyone may use the tools. Students sketch first ideas for their chosen product at the end of the week.</p>
 <h3>Case Study</h3>
 <p>Alex rushes into the workshop without putting on safety glasses or clearing his bag. He grabs a piece of metal and begins drilling without asking for help or clamping the work. This scenario highlights numerous safety breaches: missing PPE, trip hazards and failing to secure the workpiece. Through Alex’s mistakes we learn the correct procedures: clear the space, wear protective gear, clamp your material and seek teacher guidance before using any machine.</p>
 <h3>Quiz</h3>
@@ -69,7 +69,7 @@
 <label><input type="radio" name="q6" value="D" required> D. There is no good reason</label>
 <br>
 
-<p>7. Why is mild steel chosen over wood or plastic for the hose holder project?</p>
+<p>7. Why is mild steel often chosen over wood or plastic for outdoor metal projects?</p>
 <label><input type="radio" name="q7" value="A" required> A. Because it is strong, weather resistant and still workable by hand</label>
 <label><input type="radio" name="q7" value="B" required> B. Because it is always cheaper than wood</label>
 <label><input type="radio" name="q7" value="C" required> C. Because wood cannot be cut or shaped</label>
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit10.html
+++ b/unit10.html
@@ -22,7 +22,7 @@
 <div class="card">
 <img src="img/header_abstract.png" alt="Illustration" class="responsive">
 <h2>Week 10 – Final Assessment & Reflection</h2>
-<p>The final week wraps up the unit. Students submit their portfolios and completed hose holders for assessment. The teacher evaluates the artifact using criteria such as function, construction quality, finish and adherence to the brief. Students may give short presentations demonstrating how their holder works and summarising their project. There may be a short written quiz covering safety, tools, design process and finishing. Finally, the class reflects on what they enjoyed, what was challenging and how the skills learned relate to real‑world technology and trades.</p>
+<p>The final week wraps up the unit. Students submit their portfolios and completed projects for assessment. The teacher evaluates the artifact using criteria such as function, construction quality, finish and adherence to the brief. Students may give short presentations demonstrating how their solution works and summarising their project. There may be a short written quiz covering safety, tools, design process and finishing. Finally, the class reflects on what they enjoyed, what was challenging and how the skills learned relate to real‑world technology and trades.</p>
 <h3>Case Study</h3>
 <p>During the reflection circle, students share their experiences. Anya says she was nervous using tools at first but now feels confident. Brian learned the hard way to ‘measure twice’ after cutting a piece too short. Carlos discovered he enjoys the creativity in design and might take more technology subjects. The teacher notes that these skills – problem solving, planning, hands‑on tool work – mirror what professionals do.</p>
 <h3>Quiz</h3>
@@ -82,7 +82,7 @@
 <label><input type="radio" name="q9" value="D" required> D. Boredom from having made nothing</label>
 <br>
 <p>10. Which summary best describes the 10‑week project?</p>
-<label><input type="radio" name="q10" value="A" required> A. Over the term I learned to design, plan and build a metal hose holder from scratch, gaining practical skills and an appreciation for safety, accuracy and creativity</label>
+<label><input type="radio" name="q10" value="A" required> A. Over the term I learned to design, plan and build a metal project from scratch, gaining practical skills and an appreciation for safety, accuracy and creativity</label>
 <label><input type="radio" name="q10" value="B" required> B. It was just busy work</label>
 <label><input type="radio" name="q10" value="C" required> C. The project had no purpose</label>
 <label><input type="radio" name="q10" value="D" required> D. We simply played with metal</label>
@@ -93,6 +93,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit10_advanced.html
+++ b/unit10_advanced.html
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit1_advanced.html
+++ b/unit1_advanced.html
@@ -31,11 +31,11 @@
         <textarea name="q1" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
-        <p>2. Pick another metal (e.g. aluminium or stainless steel) and compare its properties to mild steel for making a hose holder. Would it be a better choice? Explain.</p>
+        <p>2. Pick another metal (e.g. aluminium or stainless steel) and compare its properties to mild steel for making an outdoor, load‑bearing project. Would it be a better choice? Explain.</p>
         <textarea name="q2" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
-        <p>3. Think of an additional feature to add to your hose holder (for example, a clip to secure the hose end). Sketch or describe your idea and explain how it would help.</p>
+        <p>3. Think of an additional feature to add to your project (for example, a clip to secure a stored item). Sketch or describe your idea and explain how it would help.</p>
         <textarea name="q3" rows="5" required></textarea>
       </div>
       <button type="submit">Submit Responses</button>
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit1_support.html
+++ b/unit1_support.html
@@ -27,7 +27,7 @@
             <label><input data-correct="false" name="w1_q1" type="radio"> D. Because everyone else does</label>
           </li>
           <li>
-            <p>What material is chosen for the hose holder because it’s strong and can handle the weather?</p>
+            <p>What material is chosen for an outdoor metal project because it’s strong and can handle the weather?</p>
             <label><input data-correct="false" name="w1_q2" type="radio"> A. Plastic</label><br>
             <label><input data-correct="true"  name="w1_q2" type="radio"> B. Mild steel</label><br>
             <label><input data-correct="false" name="w1_q2" type="radio"> C. Aluminium foil</label><br>

--- a/unit2.html
+++ b/unit2.html
@@ -22,12 +22,12 @@
 <div class="card">
 <img src="img/blueprint.png" alt="Illustration" class="responsive">
 <h2>Week 2 – Design & Planning</h2>
-<p>In Week 2 students follow the design process: investigate, ideate and plan. They research existing hose holders, brainstorm several different concepts and decide on the best idea by comparing how well each meets the criteria. Once a concept is chosen, they draw detailed plans with dimensions, compile a list of materials, and write a step‑by‑step production plan. Planning ahead saves time and materials later; the old saying ‘measure twice, cut once’ applies. Students learn to adjust designs to suit available tools and resources.</p>
+<p>In Week 2 students follow the design process: investigate, ideate and plan. They research existing products, brainstorm several different concepts and decide on the best idea by comparing how well each meets the criteria. Once a concept is chosen, they draw detailed plans with dimensions, compile a list of materials, and write a step‑by‑step production plan. Planning ahead saves time and materials later; the old saying ‘measure twice, cut once’ applies. Students learn to adjust designs to suit available tools and resources.</p>
 <h3>Case Study</h3>
-<p>Jordan drew a quick sketch for his holder and said he would figure out the rest later. He forgot to include a mounting plate, so when it came time to assemble he had no way to attach the holder to the wall. Sam, however, explored several designs, made a cardboard model to test the size, and wrote out a list of materials and steps. Her project came together smoothly. This case shows how careful planning prevents problems.</p>
+<p>Jordan drew a quick sketch for his project and said he would figure out the rest later. He forgot to include a mounting plate, so when it came time to assemble he had no way to attach the product to the wall. Sam, however, explored several designs, made a cardboard model to test the size, and wrote out a list of materials and steps. Her project came together smoothly. This case shows how careful planning prevents problems.</p>
 <h3>Quiz</h3>
 <form class="quiz-form" data-unit="2" aria-label="Quiz">
-<p>1. In the case study, what planning misstep led to Jordan’s inability to mount his holder?</p>
+<p>1. In the case study, what planning misstep led to Jordan’s inability to mount his project?</p>
 <label><input type="radio" name="q1" value="A" required> A. He brainstormed too many possible designs</label>
 <label><input type="radio" name="q1" value="B" required> B. He failed to include a mounting plate or attachment method in his plan</label>
 <label><input type="radio" name="q1" value="C" required> C. He took the safety test too late</label>
@@ -41,8 +41,8 @@
 <label><input type="radio" name="q2" value="D" required> D. Avoid looking at existing solutions</label>
 <br>
 
-<p>3. Which of these is the most critical design criterion for the hose holder?</p>
-<label><input type="radio" name="q3" value="A" required> A. It must support the weight of a coiled garden hose without deforming</label>
+<p>3. Which of these is the most critical design criterion for a wall‑mounted metal project?</p>
+<label><input type="radio" name="q3" value="A" required> A. It must support the expected load without deforming</label>
 <label><input type="radio" name="q3" value="B" required> B. It needs to be painted bright red</label>
 <label><input type="radio" name="q3" value="C" required> C. It should cost more than $100 to make</label>
 <label><input type="radio" name="q3" value="D" required> D. It should be as complex as possible</label>
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit2_advanced.html
+++ b/unit2_advanced.html
@@ -44,6 +44,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit2_support.html
+++ b/unit2_support.html
@@ -26,7 +26,7 @@
             <label><input data-correct="false" name="w2_q1" type="radio"> D. Waiting for someone else to decide</label>
           </li>
           <li>
-            <p>Which of the following should you do before starting to build your hose holder?</p>
+            <p>Which of the following should you do before starting to build your project?</p>
             <label><input data-correct="false" name="w2_q2" type="radio"> A. Start cutting immediately</label><br>
             <label><input data-correct="true"  name="w2_q2" type="radio"> B. Decide on sizes, list materials and plan the steps</label><br>
             <label><input data-correct="false" name="w2_q2" type="radio"> C. Ask your friend to build it for you</label><br>

--- a/unit3.html
+++ b/unit3.html
@@ -22,7 +22,7 @@
 <div class="card">
 <img src="img/parts_blueprint.png" alt="Illustration" class="responsive">
 <h2>Week 3 – Tools & Marking Out</h2>
-<p>Students begin hands‑on work by learning to mark out and cut metal accurately. They practise using measuring tools such as steel rulers, tape measures and try squares, and marking tools like scribes and centre punches. Accurate marking lines and centre punch indentations ensure holes and cuts are placed correctly. Cutting tools include hacksaws for bar stock and snips or shears for sheet metal. Workpieces must always be clamped in a vice before cutting or drilling to avoid accidents. Files are used to remove burrs and sharp edges. Students mark out and rough cut the components for their hose holder this week.</p>
+<p>Students begin hands‑on work by learning to mark out and cut metal accurately. They practise using measuring tools such as steel rulers, tape measures and try squares, and marking tools like scribes and centre punches. Accurate marking lines and centre punch indentations ensure holes and cuts are placed correctly. Cutting tools include hacksaws for bar stock and snips or shears for sheet metal. Workpieces must always be clamped in a vice before cutting or drilling to avoid accidents. Files are used to remove burrs and sharp edges. Students mark out and rough cut the components for their project this week.</p>
 <h3>Case Study</h3>
 <p>Taylor measures a piece of flat bar for a 25 cm length, uses a scribe and try square to draw a clear line, clamps the bar firmly in a vice and cuts along the line with a hacksaw. His cut is straight and accurate. Lee, however, guesses the length, scratches a faint line with a pen and holds the bar in his hand while cutting. His piece ends up crooked and off by a centimetre, and nearly slips causing an injury. The difference shows why careful marking and clamping are essential.</p>
 <h3>Quiz</h3>
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit3_advanced.html
+++ b/unit3_advanced.html
@@ -44,6 +44,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit4.html
+++ b/unit4.html
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit4_advanced.html
+++ b/unit4_advanced.html
@@ -44,6 +44,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit5.html
+++ b/unit5.html
@@ -24,7 +24,7 @@
 <h2>Week 5 – Joining Techniques</h2>
 <p>Once all parts are cut and shaped, students join them. We explore mechanical fastening (bolts, screws and rivets) and permanent methods (welding and brazing). Mechanical fasteners allow parts to be taken apart; welds and brazes fuse the metal permanently. Welding melts the base metal; brazing uses a filler metal such as brass that melts at a lower temperature. Glue or epoxy is not suitable for structural metal joins. Safety when welding or brazing includes wearing a helmet with a dark visor, leather gloves and long sleeves, and ensuring good ventilation. Surfaces must be clean and fit well before joining.</p>
 <h3>Case Study</h3>
-<p>Alex tried to glue his steel bracket to the mounting plate with epoxy. When he hung the hose on the holder, the glue joint failed immediately. Nina prepared her surfaces properly, clamped the parts and brazed them with help from the teacher. Her joint has a smooth fillet of brass and easily holds the load. This illustrates why appropriate joining methods are critical.</p>
+<p>Alex tried to glue his steel bracket to the mounting plate with epoxy. When he loaded the assembly, the glue joint failed immediately. Nina prepared her surfaces properly, clamped the parts and brazed them with help from the teacher. Her joint has a smooth fillet of brass and easily holds the load. This illustrates why appropriate joining methods are critical.</p>
 <h3>Quiz</h3>
 <form class="quiz-form" data-unit="5" aria-label="Quiz">
 <p>1. Alex tried to glue his metal bracket to the mounting plate. Why did his joint fail?</p>
@@ -55,9 +55,9 @@
 <label><input type="radio" name="q4" value="D" required> D. Using epoxy glue as the sole fastener</label>
 <br>
 
-<p>5. To mount the hose holder securely to a wall you should integrate…</p>
+<p>5. To mount a wall‑hung project securely you should integrate…</p>
 <label><input type="radio" name="q5" value="A" required> A. A flat plate or bracket with properly positioned screw or bolt holes</label>
-<label><input type="radio" name="q5" value="B" required> B. Nothing – simply weld the holder directly to the wall</label>
+<label><input type="radio" name="q5" value="B" required> B. Nothing – simply weld the project directly to the wall</label>
 <label><input type="radio" name="q5" value="C" required> C. A glued wooden block</label>
 <label><input type="radio" name="q5" value="D" required> D. A layer of paint to stick it</label>
 <br>
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit5_advanced.html
+++ b/unit5_advanced.html
@@ -31,7 +31,7 @@
         <textarea name="q1" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
-        <p>2. Describe a simple test you could perform on your joint to check its strength before installing the holder at home.</p>
+        <p>2. Describe a simple test you could perform on your joint to check its strength before putting the project into service.</p>
         <textarea name="q2" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit5_support.html
+++ b/unit5_support.html
@@ -12,7 +12,7 @@
   <summary><b>Week&nbsp;5: Joining Techniques</b></summary>
   <article>
     <h4>Support Theory</h4>
-    <p>You learn different ways to join metal. Bolts and screws can be undone; welds and brazes permanently fuse the pieces. Glue is not strong enough for a hose holder. Always wear proper protection when welding or brazing and make sure the parts fit well before joining.</p>
+    <p>You learn different ways to join metal. Bolts and screws can be undone; welds and brazes permanently fuse the pieces. Glue is not strong enough for load‑bearing metal projects. Always wear proper protection when welding or brazing and make sure the parts fit well before joining.</p>
 
     <form class="quiz" data-week="Week 5" id="support-week5-quiz">
       <fieldset>
@@ -26,7 +26,7 @@
             <label><input data-correct="false" name="w5_q1" type="radio"> D. Gluing them</label>
           </li>
           <li>
-            <p>Why don’t we use glue for the hose holder?</p>
+            <p>Why don’t we use glue as the main join for a load‑bearing metal project?</p>
             <label><input data-correct="false" name="w5_q2" type="radio"> A. It’s messy</label><br>
             <label><input data-correct="true"  name="w5_q2" type="radio"> B. It isn’t strong enough to hold metal parts securely</label><br>
             <label><input data-correct="false" name="w5_q2" type="radio"> C. It’s too expensive</label><br>

--- a/unit6.html
+++ b/unit6.html
@@ -22,7 +22,7 @@
 <div class="card">
 <img src="img/parts_blueprint.png" alt="Illustration" class="responsive">
 <h2>Week 6 – Project Construction</h2>
-<p>Week 6 is assembly week. Students attach the shaped parts together using the chosen joining method. They check alignment carefully and fix small errors: holes that don’t line up may need to be enlarged slightly; pieces that are too long can be trimmed. It’s important to refer back to the design drawings during assembly to ensure the project matches the plan. If something is crooked, students learn how to straighten it under supervision. By the end of the week, the hose holder should be fully assembled and ready for finishing.</p>
+<p>Week 6 is assembly week. Students attach the shaped parts together using the chosen joining method. They check alignment carefully and fix small errors: holes that don’t line up may need to be enlarged slightly; pieces that are too long can be trimmed. It’s important to refer back to the design drawings during assembly to ensure the project matches the plan. If something is crooked, students learn how to straighten it under supervision. By the end of the week, the project should be fully assembled and ready for finishing.</p>
 <h3>Case Study</h3>
 <p>Priya discovers the holes on her mounting plate are 2 mm closer together than the holes on her bracket. She fixes the issue by drilling one hole slightly larger so the bolt will fit through both parts. James finds his frame is lopsided after welding; with the teacher’s help he reheats the joint and gently bends it straight. These examples show how minor mistakes can be corrected during assembly.</p>
 <h3>Quiz</h3>
@@ -31,7 +31,7 @@
 <label><input type="radio" name="q1" value="A" required> A. The holes on her mounting plate did not align with those on her bracket</label>
 <label><input type="radio" name="q1" value="B" required> B. She lost her bolts</label>
 <label><input type="radio" name="q1" value="C" required> C. The metal cracked in half</label>
-<label><input type="radio" name="q1" value="D" required> D. The hose wouldn’t fit at all</label>
+<label><input type="radio" name="q1" value="D" required> D. A part wouldn’t fit at all</label>
 <br>
 
 <p>2. How did Priya fix her misaligned holes?</p>
@@ -76,7 +76,7 @@
 <label><input type="radio" name="q7" value="D" required> D. So you have something to do when bored</label>
 <br>
 
-<p>8. If your holder wobbles after bolting the parts together, what can you do to improve stability?</p>
+<p>8. If your assembly wobbles after bolting the parts together, what can you do to improve stability?</p>
 <label><input type="radio" name="q8" value="A" required> A. Tighten all nuts fully and use washers or lock nuts to prevent loosening</label>
 <label><input type="radio" name="q8" value="B" required> B. Apply another coat of paint</label>
 <label><input type="radio" name="q8" value="C" required> C. Accept the wobble as part of the design</label>
@@ -91,7 +91,7 @@
 <br>
 
 <p>10. By the end of Week&nbsp;6, what should you have accomplished?</p>
-<label><input type="radio" name="q10" value="A" required> A. A fully assembled hose holder that is ready for finishing</label>
+<label><input type="radio" name="q10" value="A" required> A. A fully assembled project that is ready for finishing</label>
 <label><input type="radio" name="q10" value="B" required> B. Just a pile of individual parts</label>
 <label><input type="radio" name="q10" value="C" required> C. A finished, painted and mounted product</label>
 <label><input type="radio" name="q10" value="D" required> D. Nothing – the project is still theoretical</label>
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit6_advanced.html
+++ b/unit6_advanced.html
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit7.html
+++ b/unit7.html
@@ -22,9 +22,9 @@
 <div class="card">
 <img src="img/header_abstract.png" alt="Illustration" class="responsive">
 <h2>Week 7 – Finishing Techniques</h2>
-<p>With the holder assembled, students focus on finishing. First they deburr and file all sharp edges and sand any rough surfaces. A clean, slightly roughened surface helps paint adhere. Rust or mill scale must be removed. A primer coat is applied to bare steel to inhibit corrosion and provide a good base for the topcoat. One or more top coats of enamel or outdoor metal paint are then sprayed or brushed on. Spray painting should be done in a well‑ventilated area with a mask and goggles. Proper finishing makes the holder safe to handle and protects it from the weather. Alternative finishes such as powder coating or galvanizing can be discussed, though they require specialised equipment.</p>
+<p>With the project assembled, students focus on finishing. First they deburr and file all sharp edges and sand any rough surfaces. A clean, slightly roughened surface helps paint adhere. Rust or mill scale must be removed. A primer coat is applied to bare steel to inhibit corrosion and provide a good base for the topcoat. One or more top coats of enamel or outdoor metal paint are then sprayed or brushed on. Spray painting should be done in a well‑ventilated area with a mask and goggles. Proper finishing makes the project safe to handle and protects it from the weather. Alternative finishes such as powder coating or galvanizing can be discussed, though they require specialised equipment.</p>
 <h3>Case Study</h3>
-<p>Liam neglected to file the edges of his holder. After painting, the project looked shiny but a friend cut her hand on a burr. Liam’s paint also began to rust quickly where the paint chipped off. Ava filed all edges smooth, applied a primer and two coats of outdoor metal paint. Months later her holder still looks new. Liam also spray painted in an enclosed space without a mask and suffered headaches from the fumes. This demonstrates why proper surface prep and safe painting practices matter.</p>
+<p>Liam neglected to file the edges of his project. After painting, it looked shiny but a friend cut her hand on a burr. Liam’s paint also began to rust quickly where the paint chipped off. Ava filed all edges smooth, applied a primer and two coats of outdoor metal paint. Months later her project still looks new. Liam also spray painted in an enclosed space without a mask and suffered headaches from the fumes. This demonstrates why proper surface prep and safe painting practices matter.</p>
 <h3>Quiz</h3>
 <form class="quiz-form" data-unit="7" aria-label="Quiz">
 <p>1. What serious oversight did Liam make before painting that led to someone being cut?</p>
@@ -48,7 +48,7 @@
 <label><input type="radio" name="q3" value="D" required> D. No protective equipment is necessary</label>
 <br>
 
-<p>4. Why did Ava’s holder remain rust free while Liam’s rusted quickly?</p>
+<p>4. Why did Ava’s project remain rust free while Liam’s rusted quickly?</p>
 <label><input type="radio" name="q4" value="A" required> A. She properly prepared the surface, applied primer and multiple coats of paint to seal the metal</label>
 <label><input type="radio" name="q4" value="B" required> B. She kept it indoors at all times</label>
 <label><input type="radio" name="q4" value="C" required> C. She waxed it daily</label>
@@ -62,7 +62,7 @@
 <label><input type="radio" name="q5" value="D" required> D. Wash it with water and apply paint immediately</label>
 <br>
 
-<p>6. Which finish would be least suitable for an outdoor steel hose holder?</p>
+<p>6. Which finish would be least suitable for an outdoor steel project?</p>
 <label><input type="radio" name="q6" value="A" required> A. A durable enamel or outdoor metal paint system</label>
 <label><input type="radio" name="q6" value="B" required> B. A thin coat of household oil that must be reapplied daily</label>
 <label><input type="radio" name="q6" value="C" required> C. Powder coating or galvanising performed professionally</label>
@@ -102,6 +102,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit7_advanced.html
+++ b/unit7_advanced.html
@@ -35,7 +35,7 @@
         <textarea name="q2" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
-        <p>3. Propose a creative finishing idea that adds personal flair to your holder (e.g. two‑tone colours or a stencil). Explain how you would apply it while still protecting the metal.</p>
+        <p>3. Propose a creative finishing idea that adds personal flair to your project (e.g. two‑tone colours or a stencil). Explain how you would apply it while still protecting the metal.</p>
         <textarea name="q3" rows="5" required></textarea>
       </div>
       <button type="submit">Submit Responses</button>
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit7_support.html
+++ b/unit7_support.html
@@ -12,7 +12,7 @@
   <summary><b>Week&nbsp;7: Finishing Techniques</b></summary>
   <article>
     <h4>Support Theory</h4>
-    <p>Finishing makes the holder safe and long lasting. File off sharp edges, sand and clean the metal, then apply primer and paint. Always paint in a ventilated area wearing a mask and goggles. Proper disposal of paint and cans protects the environment.</p>
+    <p>Finishing makes the project safe and long lasting. File off sharp edges, sand and clean the metal, then apply primer and paint. Always paint in a ventilated area wearing a mask and goggles. Proper disposal of paint and cans protects the environment.</p>
 
     <form class="quiz" data-week="Week 7" id="support-week7-quiz">
       <fieldset>

--- a/unit8.html
+++ b/unit8.html
@@ -22,16 +22,16 @@
 <div class="card">
 <img src="img/hose_reel.png" alt="Illustration" class="responsive">
 <h2>Week 8 – Testing & Evaluation</h2>
-<p>With the project finished, students mount or hold their hose holders and test them. They hang a coil of hose to see if the holder supports the weight without bending, check that the hose sits securely and doesn’t slip off, and ensure the holder is stable when attached. Students time how long it takes to coil and uncoil the hose and gather peer feedback about ease of use. They evaluate their work against the criteria set during Week 2: function, strength, safety, durability and aesthetics. Students also reflect on what went well and what could be improved.</p>
+<p>With the project finished, students mount or position their product and test it. They verify that it supports the expected load without bending, check that parts sit securely and don’t slip off, and ensure the product is stable when attached. Students time or measure relevant tasks for usability and gather peer feedback about ease of use. They evaluate their work against the criteria set during Week 2: function, strength, safety, durability and aesthetics. Students also reflect on what went well and what could be improved.</p>
 <h3>Case Study</h3>
-<p>Jenny’s holder holds a standard hose well but bends slightly under a very heavy coil. She notes that using thicker metal or adding a support strut could improve it. Michael’s holder wobbles because the frame sticks out too far from the wall; he considers adding a second attachment point. Both students listen to peer feedback suggesting small improvements like adding a hook for the nozzle. They conclude that while their holders work, version 2 could be even better.</p>
+<p>Jenny’s product performs well under typical use but bends slightly under a very heavy load. She notes that using thicker metal or adding a support strut could improve it. Michael’s product wobbles because the frame sticks out too far from the wall; he considers adding a second attachment point. Both students listen to peer feedback suggesting small improvements like adding a simple accessory. They conclude that while their projects work, version 2 could be even better.</p>
 <h3>Quiz</h3>
 <form class="quiz-form" data-unit="8" aria-label="Quiz">
-<p>1. If Jenny’s holder bends slightly under a heavy load, what should she conclude?</p>
-<label><input type="radio" name="q1" value="A" required> A. It meets the need for typical use but may need thicker metal or extra support for very heavy hoses</label>
+<p>1. If Jenny’s project bends slightly under a heavy load, what should she conclude?</p>
+<label><input type="radio" name="q1" value="A" required> A. It meets the need for typical use but may need thicker metal or extra support for very heavy loads</label>
 <label><input type="radio" name="q1" value="B" required> B. It has completely failed and is useless</label>
 <label><input type="radio" name="q1" value="C" required> C. Bending is fine and not worth noting</label>
-<label><input type="radio" name="q1" value="D" required> D. She should never use it with a hose</label>
+<label><input type="radio" name="q1" value="D" required> D. She should never use it with the intended load</label>
 <br>
 <p>2. What improvement did Michael think of to reduce wobble?</p>
 <label><input type="radio" name="q2" value="A" required> A. Adding a second wall attachment point</label>
@@ -51,10 +51,10 @@
 <label><input type="radio" name="q4" value="C" required> C. How well did I follow my design and could it be improved?</label>
 <label><input type="radio" name="q4" value="D" required> D. Is it safe and durable?</label>
 <br>
-<p>5. How might you test how easily a hose coils and uncoils on your holder?</p>
-<label><input type="radio" name="q5" value="A" required> A. Actually coil and uncoil a hose a few times and note how smooth it is</label>
+<p>5. How might you test how easily your product operates during normal use?</p>
+<label><input type="radio" name="q5" value="A" required> A. Actually perform the task a few times and note how smooth it is</label>
 <label><input type="radio" name="q5" value="B" required> B. Just imagine it and assume it works</label>
-<label><input type="radio" name="q5" value="C" required> C. Roll a rope instead</label>
+<label><input type="radio" name="q5" value="C" required> C. Test something unrelated instead</label>
 <label><input type="radio" name="q5" value="D" required> D. Ignore that criterion</label>
 <br>
 <p>6. Part of evaluation is thinking “If I built this again, what would I do differently?”</p>
@@ -64,21 +64,21 @@
 <label><input type="radio" name="q6" value="D" required> D. Reflection is a waste of time</label>
 <br>
 <p>7. Which of these is a good evaluation comment?</p>
-<label><input type="radio" name="q7" value="A" required> A. The holder meets the need; it’s strong enough for a 15 m hose. Next time I’d make the hook wider for thick hoses.</label>
+<label><input type="radio" name="q7" value="A" required> A. The product meets the need; it’s strong enough for normal use. Next time I’d adjust dimensions for heavier loads.</label>
 <label><input type="radio" name="q7" value="B" required> B. It’s fine I guess</label>
 <label><input type="radio" name="q7" value="C" required> C. My project has no flaws</label>
 <label><input type="radio" name="q7" value="D" required> D. I don’t know</label>
 <br>
-<p>8. Who is the end‑user you should consider when evaluating your holder?</p>
-<label><input type="radio" name="q8" value="A" required> A. A homeowner or gardener who needs to store a hose</label>
+<p>8. Who is the end‑user you should consider when evaluating your product?</p>
+<label><input type="radio" name="q8" value="A" required> A. The person who will actually use the product</label>
 <label><input type="radio" name="q8" value="B" required> B. Just the teacher</label>
 <label><input type="radio" name="q8" value="C" required> C. No one in particular</label>
 <label><input type="radio" name="q8" value="D" required> D. The manufacturer</label>
 <br>
-<p>9. When testing your hose holder, which of the following is least critical and could reasonably be checked last?</p>
-<label><input type="radio" name="q9" value="A" required> A. Whether the holder supports the weight of a full hose</label>
-<label><input type="radio" name="q9" value="B" required> B. Whether the hose sits securely and doesn’t slip</label>
-<label><input type="radio" name="q9" value="C" required> C. How easy it is to coil and uncoil the hose</label>
+<p>9. When testing your project, which of the following is least critical and could reasonably be checked last?</p>
+<label><input type="radio" name="q9" value="A" required> A. Whether it supports the expected load</label>
+<label><input type="radio" name="q9" value="B" required> B. Whether parts sit securely and don’t slip</label>
+<label><input type="radio" name="q9" value="C" required> C. How easy it is to operate during normal use</label>
 <label><input type="radio" name="q9" value="D" required> D. The exact colour shade of the paint you used</label>
 <br>
 <p>10. Why does the syllabus emphasise doing an evaluation and reflection?</p>
@@ -93,6 +93,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit8_advanced.html
+++ b/unit8_advanced.html
@@ -27,11 +27,11 @@
     <h3>Advanced Activities – Week 8</h3>
     <form class="advanced-form" data-unit="8">
       <div class="advanced-item">
-        <p>1. Imagine you are making a version 2.0 of your holder. Describe two specific improvements you would incorporate based on your evaluation.</p>
+        <p>1. Imagine you are making a version 2.0 of your project. Describe two specific improvements you would incorporate based on your evaluation.</p>
         <textarea name="q1" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
-        <p>2. Write a short scenario of a user interacting with your holder. Identify any minor inconveniences and how you might refine the design.</p>
+        <p>2. Write a short scenario of a user interacting with your product. Identify any minor inconveniences and how you might refine the design.</p>
         <textarea name="q2" rows="5" required></textarea>
       </div>
       <div class="advanced-item">
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit8_support.html
+++ b/unit8_support.html
@@ -12,7 +12,7 @@
   <summary><b>Week&nbsp;8: Testing &amp; Evaluation</b></summary>
   <article>
     <h4>Support Theory</h4>
-    <p>Testing shows whether your holder works. Hang a hose on it, see if it holds the weight and check if it’s easy to use. Reflection helps you learn by thinking about what you would change next time.</p>
+    <p>Testing shows whether your project works. Apply a realistic load, check that it holds securely and assess ease of use. Reflection helps you learn by thinking about what you would change next time.</p>
 
     <form class="quiz" data-week="Week 8" id="support-week8-quiz">
       <fieldset>
@@ -26,9 +26,9 @@
             <label><input data-correct="false" name="w8_q1" type="radio"> D. Testing isn’t necessary</label>
           </li>
           <li>
-            <p>What should you check when testing the hose holder?</p>
+            <p>What should you check when testing a load‑bearing project?</p>
             <label><input data-correct="false" name="w8_q2" type="radio"> A. How shiny it is</label><br>
-            <label><input data-correct="true"  name="w8_q2" type="radio"> B. If it holds the hose’s weight and is easy to use</label><br>
+            <label><input data-correct="true"  name="w8_q2" type="radio"> B. If it holds the expected weight and is easy to use</label><br>
             <label><input data-correct="false" name="w8_q2" type="radio"> C. Whether it matches your favourite colour</label><br>
             <label><input data-correct="false" name="w8_q2" type="radio"> D. How heavy it feels</label>
           </li>

--- a/unit9.html
+++ b/unit9.html
@@ -93,6 +93,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/unit9_advanced.html
+++ b/unit9_advanced.html
@@ -45,6 +45,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/units.html
+++ b/units.html
@@ -42,6 +42,6 @@
   </div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/units_advanced.html
+++ b/units_advanced.html
@@ -37,6 +37,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/units_main.html
+++ b/units_main.html
@@ -9,7 +9,7 @@
 <body>
 <header>
   <h1>Main Theory Content</h1>
-  <p>Select a week to explore the detailed main theory lesson for each stage of the hose reel holder project.</p>
+  <p>Select a week to explore the detailed main theory lesson for each stage of the metalwork project unit.</p>
 </header>
 <!--
   Global navigation.  Links to the home page, all three content types
@@ -42,6 +42,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>

--- a/units_support.html
+++ b/units_support.html
@@ -37,6 +37,6 @@
 <div class="progress-container"><div class="progress-bar"></div></div>
 </main>
 <script src="script.js"></script>
-<footer>&copy; 2025 Hose Reel Holder Project</footer>
+<footer>&copy; 2025 Metalwork Project Unit</footer>
 </body>
 </html>


### PR DESCRIPTION
Generalize website content by removing all specific "hose holder" references and updating branding to "Metalwork Project Unit".

---
<a href="https://cursor.com/background-agent?bcId=bc-69222141-8e23-4461-a318-f995a193ea27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69222141-8e23-4461-a318-f995a193ea27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

