### PR TITLE
Remove question info after hyphen

### DIFF
--- a/activities.html
+++ b/activities.html
@@ -21,8 +21,8 @@
   <div class="card">
     <h2>Available Activities</h2>
     <ul>
-      <li><a href="improved_questions.html">Ben’s Workshop Safety — Improved Questions (Q1–Q10)</a></li>
-      <li><a href="drill_questions.html">Mia’s Drill Press Safety — Questions 1–10</a></li>
+      <li><a href="improved_questions.html">Ben’s Workshop Safety</a></li>
+      <li><a href="drill_questions.html">Mia’s Drill Press Safety</a></li>
     </ul>
     <p class="hint">We will add more activities here over time.</p>
   </div>


### PR DESCRIPTION
Remove trailing question information from activity link titles.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a357af4-bb5b-4c54-9a19-5d46fbd96704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a357af4-bb5b-4c54-9a19-5d46fbd96704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

