### PR TITLE
Create the standalone Hose Reel Holder unit

### DIFF
--- a/course-family-navigation.css
+++ b/course-family-navigation.css
@@ -1,0 +1,22 @@
+:root { --hub-ink: #0b3039; --hub-paper: #f5f7f4; }
+.course-family-nav { background: var(--hub-paper); border-top: 2px solid #0b3039; border-bottom: 1px solid #d7e0df; color: var(--hub-ink); position: relative; width: 100%; z-index: 1000; }
+.course-family-nav *, .course-family-nav *::before, .course-family-nav *::after { box-sizing: border-box; }
+.course-family-nav__inner { align-items: center; display: flex; gap: 1.15rem 2rem; margin: 0 auto; max-width: 1440px; min-height: 82px; padding: 0.8rem 1.25rem; }
+.course-family-nav__brand { align-items: center; color: var(--hub-ink); display: inline-flex; flex: 0 0 auto; font-size: 1.05rem; font-weight: 850; gap: 0.7rem; line-height: 1.2; text-decoration: none; }
+.course-family-nav__mark { align-items: center; background: #d99032; border-radius: 50%; color: #10252b; display: inline-flex; font-size: 0.75rem; font-weight: 900; height: 42px; justify-content: center; letter-spacing: -0.04em; width: 42px; }
+.course-family-nav__links { align-items: center; display: flex; flex: 1 1 auto; flex-wrap: wrap; gap: 0.25rem 0.4rem; }
+.course-family-nav__links a { border-radius: 12px; color: var(--hub-ink); display: inline-flex; font-size: 1rem; font-weight: 760; line-height: 1.2; padding: 0.72rem 0.78rem; text-decoration: none; white-space: nowrap; }
+.course-family-nav__links a:hover, .course-family-nav__links a:focus-visible { background: #e4eceb; color: #061c22; outline: 3px solid #cbd9d7; outline-offset: 2px; }
+.course-family-nav__links a[aria-current="page"] { background: #dce8e7; color: #0b3039; }
+.has-course-family-nav .hub-return-bar,
+.has-course-family-nav .site-header,
+.has-course-family-nav .course-bar { display: none !important; }
+@media (max-width: 780px) {
+  .course-family-nav { position: relative; }
+  .course-family-nav__inner { display: grid; gap: 0.6rem; min-height: 0; padding: 0.7rem 0.8rem 0.55rem; }
+  .course-family-nav__brand { font-size: 1rem; }
+  .course-family-nav__mark { height: 36px; width: 36px; }
+  .course-family-nav__links { flex-wrap: nowrap; margin-inline: -0.8rem; overflow-x: auto; padding: 0 0.8rem 0.45rem; scrollbar-width: thin; }
+  .course-family-nav__links a { flex: 0 0 auto; font-size: 0.92rem; padding: 0.62rem 0.72rem; }
+}
+@media print { .course-family-nav { display: none !important; } }

--- a/folio.html
+++ b/folio.html
@@ -2,11 +2,11 @@
 <html lang="en-AU">
 <head>
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Project folio | Year 8 Metalwork</title><link rel="stylesheet" href="guided/course.css">
+  <title>Hose Reel Holder | Project folio</title><link rel="stylesheet" href="guided/course.css">
 </head>
 <body>
-  <header class="site-header"><div class="nav-wrap"><a class="brand" href="index.html">Year 8 Metalwork</a><nav class="nav-links"><a href="index.html#pathway">Modules</a><a href="folio.html">Folio</a><a href="index.html#resources">Resources</a></nav></div></header>
-  <section class="module-hero"><div class="module-hero-inner"><p class="eyebrow">12-part evidence folio</p><h1>Hose Reel Holder folio</h1><p>Build a clear evidence trail from brief to evaluation. Follow the teacher’s task notification for any additional requirements.</p></div></section>
+  <header class="site-header"><div class="nav-wrap"><a class="brand" href="index.html">Hose Reel Holder</a><nav class="nav-links"><a href="index.html#pathway">Modules</a><a href="folio.html">Folio</a><a href="index.html#resources">Resources</a></nav></div></header>
+  <section class="module-hero"><div class="module-hero-inner"><p class="eyebrow">12-part evidence folio</p><h1>Hose Reel Holder Project Folio</h1><p>Build a clear evidence trail from brief to evaluation. Follow the teacher’s task notification for any additional requirements.</p></div></section>
   <main class="folio-main" data-folio>
     <section class="card progress-panel"><div class="student-grid"><label>Student name<input data-save data-required name="student-name" type="text"></label><label>Class<input data-save data-required name="student-class" type="text"></label></div><p class="save-state" data-save-state>Autosaves on this browser and device.</p><div class="button-row"><button class="btn" onclick="window.print()">Print / Save PDF</button><a class="btn ghost" href="index.html">Course home</a></div></section>
     <div class="folio-grid">

--- a/folio.html
+++ b/folio.html
@@ -26,6 +26,6 @@
   </main>
   <footer>Keep evidence specific, honest and connected to your own project work.</footer>
   <script src="guided/data.js"></script><script src="guided/course.js"></script>
-<script src="/Yr-8-Metal-Technology/shared/hub-navigation.js" defer></script>
+<script src="shared/hub-navigation.js?v=20260814" defer></script>
 </body>
 </html>

--- a/guided/data.js
+++ b/guided/data.js
@@ -1,5 +1,5 @@
 window.COURSE_DATA = {
-  shortTitle: "Year 8 Metalwork",
+  shortTitle: "Hose Reel Holder",
   storagePrefix: "yr8-metal-guided",
   modules: [
     {

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Year 8 Metalwork guided course for the hose reel holder project.">
-  <title>Year 8 Metalwork | Hose Reel Holder</title>
+  <meta name="description" content="Year 8 Metalwork guided course for the Hose Reel Holder project.">
+  <title>Hose Reel Holder | Year 8 Metalwork</title>
 <link rel="stylesheet" href="guided/course.css">
 <link rel="stylesheet" href="shared/sister-site.css" data-sister-site-styles>
 <link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
@@ -16,7 +16,7 @@
 <body>
   <header class="site-header">
     <div class="nav-wrap">
-      <a class="brand" href="index.html">Year 8 Metalwork</a>
+      <a class="brand" href="index.html">Hose Reel Holder</a>
       <nav class="nav-links" aria-label="Course navigation">
         <a href="#pathway">Modules</a><a href="#outcomes">Outcomes</a><a href="#assessment">Assessment</a><a href="#resources">Resources</a><a href="folio.html">Folio</a>
       </nav>
@@ -27,8 +27,8 @@
     <section class="hero sister-hero course-family-hero" style="--hero-start:#203344;--hero-end:#52738b;--hero-accent:#efb35f">
       <div class="hero-inner course-family-hero-inner"><div class="hero-copy">
         <p class="eyebrow">Stage 4 · Materials and production processes</p>
-        <h1>Year 8 Metalwork</h1>
-        <p>Build the thinking, safety and production skills behind the outdoor hose reel holder—one checked stage at a time.</p>
+        <h1>Hose Reel Holder</h1>
+        <p>Read the project. Work with control. Prove the process.</p>
         <div class="hero-actions"><a class="btn" href="module.html?module=1">Start Module 1</a><a class="btn secondary" href="folio.html">Open Project Folio</a></div>
       </div><figure class="hero-showcase"><img src="img/hero-year8-metal.png" alt="Metalwork bench prepared for the Year 8 hose reel holder project"></figure></div>
     </section>
@@ -36,8 +36,8 @@
     <section class="course-family-intro" aria-labelledby="course-family-intro-title">
   <div class="course-family-intro__inner">
     <header class="course-family-intro__heading">
-      <p class="course-family-intro__eyebrow">Stage 4 Materials and Production Processes</p>
-      <h2 id="course-family-intro-title">The outdoor hose reel holder project</h2>
+      <p class="course-family-intro__eyebrow">Year 8 Metalwork</p>
+      <h2 id="course-family-intro-title">Hose Reel Holder</h2>
       <p class="course-family-intro__lede">This guided pathway supports the existing project through five two-week modules. Teacher-issued plans and demonstrations control dimensions, components and production details.</p>
     </header>
     <div class="course-family-intro__routine">
@@ -100,6 +100,6 @@
       </div>
     </section>
   </main>
-  <footer>Year 8 Metalwork · Hose Reel Holder · Student work autosaves only in this browser and on this device.</footer>
+  <footer>Hose Reel Holder · Year 8 Metalwork · Student work autosaves only in this browser and on this device.</footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,10 @@
   <title>Year 8 Metalwork | Hose Reel Holder</title>
 <link rel="stylesheet" href="guided/course.css">
 <link rel="stylesheet" href="shared/sister-site.css" data-sister-site-styles>
+<link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
 <link rel="stylesheet" href="course-family-hero.css">
 <link rel="stylesheet" href="front-page-cleanup.css">
-<script src="shared/hub-navigation.js" defer></script>
+<script src="shared/hub-navigation.js?v=20260814" defer></script>
   <link rel="stylesheet" href="course-family-intro.css">
 <link rel="stylesheet" href="module-pathway.css"></head>
 <body>

--- a/module.html
+++ b/module.html
@@ -11,6 +11,6 @@
   <main class="module-main" data-module-host></main>
   <footer>Follow teacher-issued plans, demonstrations and workshop instructions for every practical step.</footer>
   <script src="guided/data.js"></script><script src="guided/course.js"></script>
-<script src="/Yr-8-Metal-Technology/shared/hub-navigation.js" defer></script>
+<script src="shared/hub-navigation.js?v=20260814" defer></script>
 </body>
 </html>

--- a/module.html
+++ b/module.html
@@ -2,11 +2,11 @@
 <html lang="en-AU">
 <head>
   <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Guided module | Year 8 Metalwork</title>
+  <title>Guided module | Hose Reel Holder</title>
   <link rel="stylesheet" href="guided/course.css">
 </head>
 <body>
-  <header class="site-header"><div class="nav-wrap"><a class="brand" href="index.html">Year 8 Metalwork</a><nav class="nav-links" aria-label="Course navigation"><a href="index.html#pathway">Modules</a><a href="folio.html">Folio</a><a href="index.html#resources">Resources</a></nav></div></header>
+  <header class="site-header"><div class="nav-wrap"><a class="brand" href="index.html">Hose Reel Holder</a><nav class="nav-links" aria-label="Course navigation"><a href="index.html#pathway">Modules</a><a href="folio.html">Folio</a><a href="index.html#resources">Resources</a></nav></div></header>
   <section class="module-hero"><div class="module-hero-inner"><p class="eyebrow" data-module-kicker></p><h1 data-module-title></h1><p data-module-summary></p></div></section>
   <main class="module-main" data-module-host></main>
   <footer>Follow teacher-issued plans, demonstrations and workshop instructions for every practical step.</footer>

--- a/project-resource.html
+++ b/project-resource.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Confirmed project scope and source boundaries for the Year 8 Hose Reel Holder unit.">
+  <title>Project Resource | Hose Reel Holder</title>
+  <link rel="stylesheet" href="guided/course.css">
+  <link rel="stylesheet" href="shared/sister-site.css" data-sister-site-styles>
+  <link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
+  <script src="shared/hub-navigation.js?v=20260814" defer></script>
+  <style>
+    .resource-main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 46px 0 80px; }
+    .resource-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 22px; }
+    @media (max-width: 600px) { .resource-main { width: calc(100% - 22px); padding-top: 28px; } .resource-actions .btn { width: 100%; text-align: center; } }
+    @media print { .resource-actions, footer { display: none !important; } .resource-main { width: 100%; padding: 0; } .card { break-inside: avoid; box-shadow: none !important; } }
+  </style>
+</head>
+<body>
+  <main class="resource-main">
+    <p class="eyebrow">Year 8 Metalwork · Project resource</p>
+    <h1>Hose Reel Holder</h1>
+    <p class="section-intro">Use this page to confirm the project purpose, learning pathway and source boundary before practical work.</p>
+
+    <section class="card" style="margin-top:24px">
+      <h2>Confirmed project purpose</h2>
+      <p>The unit centres on an outdoor mild-steel holder that stores and supports a garden hose reel. Students consider the user, outdoor conditions, strength, access, construction quality and evidence across the project.</p>
+    </section>
+
+    <section class="card" style="margin-top:24px">
+      <h2>Five-module pathway</h2>
+      <ol>
+        <li>Project purpose and workshop readiness</li>
+        <li>Design, plans and accurate marking</li>
+        <li>Cut, shape and drill under control</li>
+        <li>Join, assemble and protect</li>
+        <li>Test, evaluate and present evidence</li>
+      </ol>
+      <div class="resource-actions"><a class="btn" href="module.html?module=1">Start Module 1</a><a class="btn secondary" href="folio.html">Open Project Folio</a></div>
+    </section>
+
+    <section class="card pending" style="margin-top:24px">
+      <h2>Technical authority</h2>
+      <p>The teacher-issued plan and current school documents control the exact form, dimensions, components, materials, tolerances, machine settings, practical methods and permission points. The teacher’s assessment notification controls dates, weighting, criteria and submission requirements. Website summaries do not replace those sources.</p>
+    </section>
+  </main>
+  <footer>Hose Reel Holder · Year 8 Metalwork · Project resource.</footer>
+</body>
+</html>

--- a/shared/hub-navigation.js
+++ b/shared/hub-navigation.js
@@ -21,7 +21,7 @@
 
   const nav = document.createElement("nav");
   nav.className = "course-family-nav screen-only";
-  nav.setAttribute("aria-label", "Year 8 Metalwork course navigation");
+  nav.setAttribute("aria-label", "Hose Reel Holder course navigation");
 
   const inner = document.createElement("div");
   inner.className = "course-family-nav__inner";
@@ -29,7 +29,7 @@
   const brand = document.createElement("a");
   brand.className = "course-family-nav__brand";
   brand.href = new URL("index.html", root).href;
-  brand.innerHTML = '<span class="course-family-nav__mark" aria-hidden="true">M8</span><span>Year 8 Metalwork</span>';
+  brand.innerHTML = '<span class="course-family-nav__mark" aria-hidden="true">HR</span><span>Hose Reel Holder</span>';
 
   const links = document.createElement("div");
   links.className = "course-family-nav__links";
@@ -40,7 +40,7 @@
     ["Video learning", "youtube-library/video-library.html", path.includes("/youtube-library/")],
     ["Busy Work", "https://stevencowell.github.io/busy-worksheets/?library=metal", false, true],
     ["My folio", "folio.html", path.endsWith("/folio.html")],
-    ["Project resource", "index.html#resources", isHome && location.hash === "#resources"],
+    ["Project resource", "project-resource.html", path.endsWith("/project-resource.html")],
     ["Teacher resources", "teacher-resources.html", path.includes("/teacher-resources")],
     ["Main Menu", "https://stevencowell.github.io/Main-Page/", false, true]
   ];

--- a/shared/hub-navigation.js
+++ b/shared/hub-navigation.js
@@ -1,45 +1,60 @@
 (function () {
   "use strict";
 
-  const HUB_URL = "https://stevencowell.github.io/Main-Page/";
-  const BUSY_WORK_URL = "https://stevencowell.github.io/busy-worksheets/?library=metal";
-  const script = document.currentScript;
-  const stylesheetUrl = script ? new URL("sister-site.css", script.src).href : "";
+  if (document.querySelector(".course-family-nav")) return;
 
-  if (stylesheetUrl && !document.querySelector('link[data-sister-site-styles]')) {
+  const script = document.currentScript;
+  const root = new URL("../", script && script.src ? script.src : location.href);
+  const stylesheetUrl = new URL("course-family-navigation.css?v=20260814", root).href;
+
+  if (!document.querySelector("link[data-course-family-nav-styles]")) {
     const stylesheet = document.createElement("link");
     stylesheet.rel = "stylesheet";
     stylesheet.href = stylesheetUrl;
-    stylesheet.dataset.sisterSiteStyles = "";
+    stylesheet.dataset.courseFamilyNavStyles = "";
     document.head.append(stylesheet);
   }
 
-  if (document.querySelector(".hub-return-bar")) return;
+  const path = location.pathname.toLowerCase();
+  const rootPath = root.pathname.replace(/\/$/, "").toLowerCase();
+  const isHome = path === `${rootPath}/` || path === `${rootPath}/index.html`;
 
-  const heading = document.querySelector("h1");
-  const courseLabel = heading && heading.textContent.trim() ? heading.textContent.trim() : document.title;
-  const bar = document.createElement("nav");
-  bar.className = "hub-return-bar screen-only";
-  bar.setAttribute("aria-label", "Industrial Arts Learning Hub navigation");
+  const nav = document.createElement("nav");
+  nav.className = "course-family-nav screen-only";
+  nav.setAttribute("aria-label", "Year 8 Metalwork course navigation");
 
   const inner = document.createElement("div");
-  inner.className = "hub-return-inner";
+  inner.className = "course-family-nav__inner";
 
-  const link = document.createElement("a");
-  link.className = "hub-return-link";
-  link.href = HUB_URL;
-  link.innerHTML = '<span aria-hidden="true">←</span><span>Main menu · Industrial Arts Learning Hub</span>';
+  const brand = document.createElement("a");
+  brand.className = "course-family-nav__brand";
+  brand.href = new URL("index.html", root).href;
+  brand.innerHTML = '<span class="course-family-nav__mark" aria-hidden="true">M8</span><span>Year 8 Metalwork</span>';
 
-  const label = document.createElement("span");
-  label.className = "hub-course-label";
-  label.textContent = courseLabel;
+  const links = document.createElement("div");
+  links.className = "course-family-nav__links";
 
-  const busyWork = document.createElement("a");
-  busyWork.className = "hub-return-link";
-  busyWork.href = BUSY_WORK_URL;
-  busyWork.textContent = "Busy Work";
+  const items = [
+    ["Course", "index.html", isHome],
+    ["Modules", "index.html#pathway", path.endsWith("/module.html")],
+    ["Video learning", "youtube-library/video-library.html", path.includes("/youtube-library/")],
+    ["Busy Work", "https://stevencowell.github.io/busy-worksheets/?library=metal", false, true],
+    ["My folio", "folio.html", path.endsWith("/folio.html")],
+    ["Project resource", "index.html#resources", isHome && location.hash === "#resources"],
+    ["Teacher resources", "teacher-resources.html", path.includes("/teacher-resources")],
+    ["Main Menu", "https://stevencowell.github.io/Main-Page/", false, true]
+  ];
 
-  inner.append(link, busyWork, label);
-  bar.append(inner);
-  document.body.prepend(bar);
+  items.forEach(([label, href, current, external]) => {
+    const link = document.createElement("a");
+    link.textContent = label;
+    link.href = external ? href : new URL(href, root).href;
+    if (current) link.setAttribute("aria-current", "page");
+    links.append(link);
+  });
+
+  inner.append(brand, links);
+  nav.append(inner);
+  document.body.prepend(nav);
+  document.documentElement.classList.add("has-course-family-nav");
 })();

--- a/teacher-resources.html
+++ b/teacher-resources.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Teacher resources and source boundaries for the Year 8 Metalwork course.">
   <meta name="robots" content="noindex">
-  <title>Teacher Resources | Year 8 Metalwork</title>
+  <title>Teacher Resources | Hose Reel Holder</title>
   <link rel="stylesheet" href="guided/course.css">
   <link rel="stylesheet" href="shared/sister-site.css" data-sister-site-styles>
   <link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
@@ -19,7 +19,7 @@
 </head>
 <body>
   <main class="teacher-main">
-    <p class="eyebrow">Teacher resources · Year 8 Metalwork</p>
+    <p class="eyebrow">Teacher resources · Hose Reel Holder</p>
     <h1>Hose reel holder course controls</h1>
     <p class="section-intro">This page keeps the student pathway, local authority and staff change process together. It does not replace the approved school program, assessment notification, teacher-issued project plan or current workshop procedures.</p>
 
@@ -31,7 +31,7 @@
     <section class="card" style="margin-top:24px">
       <h2>Student evidence</h2>
       <p>Module checks, written explanations and folio work are stored in the student’s browser. Students should keep a PDF backup and follow the teacher-approved submission process. Nothing is submitted automatically.</p>
-      <div class="teacher-actions"><a class="btn" href="index.html">Course home</a><a class="btn secondary" href="assessment-pathway-2026.html">Assessment pathway</a></div>
+      <div class="teacher-actions"><a class="btn" href="index.html">Course home</a><a class="btn secondary" href="project-resource.html">Project resource</a><a class="btn secondary" href="assessment-pathway-2026.html">Assessment pathway</a></div>
     </section>
 
     <section class="card" style="margin-top:24px">
@@ -41,6 +41,6 @@
       <div class="teacher-actions"><a class="btn" href="https://github.com/stevencowell/Yr-8-Metal-Technology/issues/new?title=Year%208%20Metalwork%20course%20change%20request&body=Page%20or%20module%3A%0A%0ASuggested%20change%3A%0A%0AApproved%20source%3A%0A" target="_blank" rel="noopener">Suggest a Change</a></div>
     </section>
   </main>
-  <footer>Year 8 Metalwork · Teacher resources · local authority remains with the school.</footer>
+  <footer>Hose Reel Holder · Teacher resources · local authority remains with the school.</footer>
 </body>
 </html>

--- a/teacher-resources.html
+++ b/teacher-resources.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en-AU">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Teacher resources and source boundaries for the Year 8 Metalwork course.">
+  <meta name="robots" content="noindex">
+  <title>Teacher Resources | Year 8 Metalwork</title>
+  <link rel="stylesheet" href="guided/course.css">
+  <link rel="stylesheet" href="shared/sister-site.css" data-sister-site-styles>
+  <link rel="stylesheet" href="course-family-navigation.css?v=20260814" data-course-family-nav-styles>
+  <script src="shared/hub-navigation.js?v=20260814" defer></script>
+  <style>
+    .teacher-main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 46px 0 80px; }
+    .teacher-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 22px; }
+    @media (max-width: 600px) { .teacher-main { width: calc(100% - 22px); padding-top: 28px; } .teacher-actions .btn { width: 100%; text-align: center; } }
+    @media print { .teacher-actions, footer { display: none !important; } .teacher-main { width: 100%; padding: 0; } .card { break-inside: avoid; box-shadow: none !important; } }
+  </style>
+</head>
+<body>
+  <main class="teacher-main">
+    <p class="eyebrow">Teacher resources · Year 8 Metalwork</p>
+    <h1>Hose reel holder course controls</h1>
+    <p class="section-intro">This page keeps the student pathway, local authority and staff change process together. It does not replace the approved school program, assessment notification, teacher-issued project plan or current workshop procedures.</p>
+
+    <section class="card pending" style="margin-top:24px">
+      <h2>Teacher-controlled project detail</h2>
+      <p>The website supports the hose reel holder project through five guided modules. Exact dimensions, components, materials, machinery settings, practical methods, permission points, assessment conditions and submission requirements remain controlled by the teacher and approved local sources.</p>
+    </section>
+
+    <section class="card" style="margin-top:24px">
+      <h2>Student evidence</h2>
+      <p>Module checks, written explanations and folio work are stored in the student’s browser. Students should keep a PDF backup and follow the teacher-approved submission process. Nothing is submitted automatically.</p>
+      <div class="teacher-actions"><a class="btn" href="index.html">Course home</a><a class="btn secondary" href="assessment-pathway-2026.html">Assessment pathway</a></div>
+    </section>
+
+    <section class="card" style="margin-top:24px">
+      <p class="eyebrow">Staff change request</p>
+      <h2>Suggest a change</h2>
+      <p>Report the affected page, the proposed correction and the approved source supporting it.</p>
+      <div class="teacher-actions"><a class="btn" href="https://github.com/stevencowell/Yr-8-Metal-Technology/issues/new?title=Year%208%20Metalwork%20course%20change%20request&body=Page%20or%20module%3A%0A%0ASuggested%20change%3A%0A%0AApproved%20source%3A%0A" target="_blank" rel="noopener">Suggest a Change</a></div>
+    </section>
+  </main>
+  <footer>Year 8 Metalwork · Teacher resources · local authority remains with the school.</footer>
+</body>
+</html>

--- a/youtube-library/video-library.data.js
+++ b/youtube-library/video-library.data.js
@@ -1,5 +1,5 @@
 window.PROJECT_VIDEO_LIBRARY = {
-  courseName: "Year 8 Metalwork",
+  courseName: "Hose Reel Holder · Year 8 Metalwork",
   title: "Hose Reel Holder video library",
   introduction: "Verified clips aligned to the five Hose Reel Holder modules. Teacher-issued plans, demonstrations and permission control every practical operation.",
   backHref: "../index.html",

--- a/youtube-library/video-library.html
+++ b/youtube-library/video-library.html
@@ -6,6 +6,7 @@
   <meta name="description" content="Project-specific curated YouTube clip library">
   <title>Project video library</title>
   <link rel="stylesheet" href="video-library.css">
+  <script src="../shared/hub-navigation.js?v=20260814" defer></script>
 </head>
 <body>
   <main class="wrap">

--- a/youtube-library/video-library.html
+++ b/youtube-library/video-library.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Project-specific curated YouTube clip library">
-  <title>Project video library</title>
+  <title>Hose Reel Holder | Video learning</title>
   <link rel="stylesheet" href="video-library.css">
   <script src="../shared/hub-navigation.js?v=20260814" defer></script>
 </head>
@@ -13,7 +13,7 @@
     <header class="library-header">
       <div>
         <p class="eyebrow" id="course-name">Guided course</p>
-        <h1 id="library-title">Project video library</h1>
+        <h1 id="library-title">Hose Reel Holder video library</h1>
         <p class="sub" id="library-introduction">Approved clips aligned to the skill currently being taught.</p>
       </div>
       <a class="back-link" id="back-link" href="../index.html">Back to course</a>


### PR DESCRIPTION
## Summary
- convert the Year 8 Metal site into a self-contained Hose Reel Holder unit
- use Hose Reel Holder as the front-page, navigation, module, folio and video-learning identity
- retain the Year 8 Metalwork and Stage 4 context
- apply the standard eight-destination course navigation
- add dedicated Project resource and Teacher resources pages
- keep Suggest a Change within Teacher resources only
- preserve the existing five-module theory, evidence and project content

## Validation
- exact draft commit rendered across the front page, Module 1, folio, video learning, Project resource and Teacher resources
- every page shows the correct Hose Reel Holder navigation and current-page state
- all supporting JavaScript parses successfully
- no horizontal overflow, broken characters or page-origin console errors
- no archived repository changed
